### PR TITLE
main thread unblocked

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -13,6 +13,12 @@ themeBackgroundColor("#fff");
 
 theme.subscribe(({ value }) => {
   themeIndicator.innerText = value;
+  console.log(value)
+  if (value === 'dark') {
+    themeTextColor("red");
+  } else {
+    themeTextColor("blue")
+  }
 });
 
 themeIndicator.innerText = theme.getValue();
@@ -25,7 +31,7 @@ const toggleThemeHandler = ({ target: { id } }) => {
       break;
     case "dark-theme":
       theme("dark");
-      themeTextColor("#fff");
+
       themeBackgroundColor("#000");
       break;
   }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,8 @@
     "build": "tsc -b tsconfig.commonjs.json tsconfig.esm.json",
     "test": "jest"
   },
-  "dependencies": {
-    "rx-dom": "7.0.3"
-  },
   "devDependencies": {
-    "@types/rx-dom": "7.0.0",
     "jest": "26.4.0",
-    "parcel-bundler": "^1.6.1",
     "typescript": "^3.9.7"
   },
   "repository": "https://github.com/adam-cyclones/reactive-css-properties",

--- a/src/utils/cssVariableObserver.ts
+++ b/src/utils/cssVariableObserver.ts
@@ -1,0 +1,27 @@
+export const cssVariableObserver = (el: Element) => {
+  const config: MutationObserverInit = {
+    subtree: false,
+    childList: false,
+    attributes: true,
+    attributeOldValue: true,
+    attributeFilter: ['style'],
+    characterData: false,
+    characterDataOldValue: false,
+  };
+
+  // set from first subscribe call
+  let rootStyleObserver!: MutationObserver;
+
+  return {
+    subscribe: (cb: MutationCallback) => {
+      if (!rootStyleObserver) {
+        rootStyleObserver = new MutationObserver(cb);
+      }
+
+      rootStyleObserver.observe(el, config)
+    },
+    unsubscribe: () => {
+      rootStyleObserver.disconnect();
+    }
+  }
+};

--- a/target/esm/index.js
+++ b/target/esm/index.js
@@ -1,7 +1,6 @@
-import rxDom from "rx-dom";
 import { camelToSnakeCase } from "./utils/camelToSnakeCase";
 import { callable } from "./utils/Callable";
-const fromMutationObserver = rxDom.DOM.fromMutationObserver;
+import { cssVariableObserver } from './utils/cssVariableObserver';
 /**
  * Set css variables and react to changes
  * */
@@ -23,13 +22,14 @@ export default (rootEl = document.documentElement, scope) => {
             const fallbackSym = Symbol('fallback');
             const nullValue = 'unset';
             // observe rootEl for style changes
-            const rootStyleOvserver = fromMutationObserver(rootEl, {
-                attributes: true,
-                attributeFilter: ["style"],
-                attributeOldValue: false,
-                childList: false,
-                subtree: false
-            });
+            const rootStyleOvserver = cssVariableObserver(rootEl);
+            // const rootStyleOvserver = fromMutationObserver(rootEl, {
+            //   attributes: true,
+            //   attributeFilter: ["style"],
+            //   attributeOldValue: false,
+            //   childList: false,
+            //   subtree: false
+            // });
             // values can exist from stylesheets and so to overload them we need to retrieve them
             let preExistingValue = window.getComputedStyle(rootEl).getPropertyValue(key);
             if (preExistingValue) {
@@ -38,6 +38,25 @@ export default (rootEl = document.documentElement, scope) => {
             previousValues[key] = {
                 value: preExistingValue || nullValue,
                 oldValue: previousValues[key] ? previousValues[key].value.toString().trim() : preExistingValue || nullValue
+            };
+            const subscribeCallback = (cb) => (change) => {
+                // @ts-ignore
+                const { oldValue } = previousValues[key];
+                const newValue = window
+                    .getComputedStyle(rootEl)
+                    .getPropertyValue(key);
+                if (oldValue !== newValue && change.length) {
+                    // kill the connection while we call the callback,
+                    // changing values by calling another prop factory causes
+                    // a memory leak, I suspect this is bug
+                    rootStyleOvserver.unsubscribe();
+                    cb({
+                        value: newValue.trim(),
+                        oldValue: oldValue
+                    });
+                    // start listening again
+                    rootStyleOvserver.subscribe(cb);
+                }
             };
             // @ts-ignore
             target[prop] = callable({
@@ -54,19 +73,7 @@ export default (rootEl = document.documentElement, scope) => {
                     rootEl.style.setProperty(key, value.toString());
                 },
                 subscribe(cb) {
-                    rootStyleOvserver.subscribe((change) => {
-                        // @ts-ignore
-                        const { oldValue } = previousValues[key];
-                        const newValue = window
-                            .getComputedStyle(rootEl)
-                            .getPropertyValue(key);
-                        if (oldValue !== newValue && change.length) {
-                            cb({
-                                value: newValue.trim(),
-                                oldValue: oldValue
-                            });
-                        }
-                    });
+                    rootStyleOvserver.subscribe(subscribeCallback(cb));
                 },
                 getUsage() {
                     return `var(${key}, ${this.getFallbackValue()})`;


### PR DESCRIPTION
switched back to non native MutationObserver instead of the rxjs wrapped observable to rule out memory leak / main thread blockage which occurred when when setting a variable inside a subscribe callback.

The cause was not RXJS which is nice but as it turns out reactive-css-properties can go dependency free! and no more leaks either, as far as I can guess its looks like registering a brand new MutationObserver inside a MutationObserver causes exponential memory usage, looping and main thread blockages, but not an overflow, could be me or it could be chrome.

This issue highlights the need to track memory when I get around to writing E2E tests (this is the next task).